### PR TITLE
Added COMPE 361 description

### DIFF
--- a/docs/instructionalcluster/usage.md
+++ b/docs/instructionalcluster/usage.md
@@ -14,7 +14,7 @@ permalink: /instructionalcluster/usage
 
 | Course | Class | Use | Semester | Instructor |
 |:-------|:------|:----|:---------|:-----------|
-| COMPE 361 Windows Programming    | 10991 | Utilizing the [**Stack Scipy**](/instructionalcluster/images) container image on the instructional cluster, students solve EE problems using Matplotlib, NumPy, HDF5, and the IEEE 745 Standard. Additionally, students solve linear equations, perform regression, interpolation, eigendecomposition, numerical quadrature, fast Fourier transforms, and solve ODEs within the container. | Spring 2023 | Paolini |
+| COMPE 361 Advanced Programming   | 10991 | Utilizing the [**Stack Scipy**](/instructionalcluster/images) container image on the instructional cluster, students solve EE problems using Matplotlib, NumPy, HDF5, and the IEEE 745 Standard. Additionally, students solve linear equations, perform regression, interpolation, eigendecomposition, numerical quadrature, fast Fourier transforms, and solve ODEs within the container. | Spring 2023 | Paolini |
 | ASTR 350 Astronomical Techniques | 13057 | ... | Spring 2023 | Quimby |
 
 ## Previous Classes

--- a/docs/instructionalcluster/usage.md
+++ b/docs/instructionalcluster/usage.md
@@ -12,9 +12,9 @@ permalink: /instructionalcluster/usage
 
 ## Active Classes
 
-| Course  | Class | Use | Semester | Instructor |
-|:--------|:------|:--------|:---------|:-----------|
-| COMPE 361 Windows Programming | 10991 | ... | Spring 2023 | Paolini |
+| Course | Class | Use | Semester | Instructor |
+|:-------|:------|:----|:---------|:-----------|
+| COMPE 361 Windows Programming    | 10991 | Utilizing the [**Stack Scipy**](/instructionalcluster/images) container image on the instructional cluster, students solve EE problems using Matplotlib, NumPy, HDF5, and the IEEE 745 Standard. Additionally, students solve linear equations, perform regression, interpolation, eigendecomposition, numerical quadrature, fast Fourier transforms, and solve ODEs within the container. | Spring 2023 | Paolini |
 | ASTR 350 Astronomical Techniques | 13057 | ... | Spring 2023 | Quimby |
 
 ## Previous Classes


### PR DESCRIPTION
Shortened Paolini's instructional cluster use description and added it to appropriate field in _Active Classes_ table of _Usage_ page. Also, included hyperlink from the container used in COMPE 361 to _Available Container Images_ page.